### PR TITLE
fix: preventing requests from being closed more than once (#47 & #48)

### DIFF
--- a/src/handler/response/AllowedRedirectDetector.ts
+++ b/src/handler/response/AllowedRedirectDetector.ts
@@ -14,7 +14,7 @@ export function createAllowedRedirectDetector(allowed: string[]): ResponseEventH
     const status = getStatusCode(headers);
     if (isRedirection(status)) {
       const location = headers.location;
-      if (location && !allowed.includes(location)) {
+      if (location && !allowed.includes(location) && !request.closed) {
         request.close();
       }
     }

--- a/src/handler/response/BannedRedirectDetector.ts
+++ b/src/handler/response/BannedRedirectDetector.ts
@@ -14,7 +14,7 @@ export function createBannedRedirectDetector(banned: string[]): ResponseEventHan
     const status = getStatusCode(headers);
     if (isRedirection(status)) {
       const location = headers.location;
-      if (location && banned.includes(location)) {
+      if (location && banned.includes(location) && !request.closed) {
         request.close();
       }
     }

--- a/src/handler/response/RefuseContentLengthLongerThanHandler.ts
+++ b/src/handler/response/RefuseContentLengthLongerThanHandler.ts
@@ -15,7 +15,8 @@ export function createRefuseContentLongerThanHandler(maxLength: number): Respons
     const status = getStatusCode(headers);
     if (
       isSuccessful(status) &&
-      (!contentLength || Number.parseInt(contentLength, 10) > maxLength)
+      (!contentLength || Number.parseInt(contentLength, 10) > maxLength) &&
+      !request.closed
     ) {
       request.close();
     }

--- a/src/handler/response/RefuseNoContentLengthHandler.ts
+++ b/src/handler/response/RefuseNoContentLengthHandler.ts
@@ -10,7 +10,7 @@ import { getStatusCode, isSuccessful } from '../../util';
 export function createRefuseNoContentLengthHandler(): ResponseEventHandler {
   return (request: ClientHttp2Stream, headers: IncomingHttpHeaders): void => {
     const status = getStatusCode(headers);
-    if (isSuccessful(status) && !headers['content-length']) {
+    if (isSuccessful(status) && !headers['content-length'] && !request.closed) {
       request.close();
     }
   };

--- a/test/integration/wrapper.test.ts
+++ b/test/integration/wrapper.test.ts
@@ -108,8 +108,7 @@ describe('The whole codebase', (): void => {
         once(contentLengthTooLongRequest, 'response'),
       ).resolves.toBeDefined();
 
-      // Both content length event handlers should close the request.
-      expect(contentLengthTooLongRequest.close).toHaveBeenCalledTimes(2);
+      expect(contentLengthTooLongRequest.close).toHaveBeenCalledTimes(1);
     });
 
     it('redirect to a banned URL.', async(): Promise<void> => {
@@ -120,8 +119,7 @@ describe('The whole codebase', (): void => {
         once(bannedRedirectRequest, 'response'),
       ).resolves.toBeDefined();
 
-      // Will be banned because it's in the blacklist and because it's not in the whitelist.
-      expect(bannedRedirectRequest.close).toHaveBeenCalledTimes(2);
+      expect(bannedRedirectRequest.close).toHaveBeenCalledTimes(1);
     });
 
     it('redirect to an allowed URL.', async(): Promise<void> => {


### PR DESCRIPTION
#### 📁 Related issues

- #47 
- #48 

#### ✍️ Description

Added checks to ``stream.closed`` when deciding to close a request stream.
